### PR TITLE
fix(wxapi):修复在请求getpubtemplatetitles时出现的200019 错误的问题

### DIFF
--- a/src/SKIT.FlurlHttpClient.Wechat.Api/Extensions/WechatApiClientExecuteWxaApiExtensions.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.Api/Extensions/WechatApiClientExecuteWxaApiExtensions.cs
@@ -112,7 +112,7 @@ namespace SKIT.FlurlHttpClient.Wechat.Api
             IFlurlRequest flurlReq = client
                 .CreateRequest(request, HttpMethod.Get, "wxaapi", "newtmpl", "getpubtemplatetitles")
                 .SetQueryParam("access_token", request.AccessToken)
-                .SetQueryParam("ids", "\"" + string.Join(",", request.CategoryIdList) + "\"")
+                .SetQueryParam("ids", string.Join(",", request.CategoryIdList))
                 .SetQueryParam("start", request.Offset)
                 .SetQueryParam("limit", request.Limit);
 


### PR DESCRIPTION
移除了转义的双引号