### PR TITLE
feat(tenpayv2): 付款码支付撤掉订单接口支持微信订单号字段

### DIFF
--- a/src/SKIT.FlurlHttpClient.Wechat.TenpayV2/Models/Pay/ReversePayOrderRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.TenpayV2/Models/Pay/ReversePayOrderRequest.cs
@@ -34,10 +34,17 @@
         public string? SubAppId { get; set; }
 
         /// <summary>
-        /// 获取或设置商户订单号。
+        /// 获取或设置商户订单号。与字段 <see cref="TransactionId"/> 二选一。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("out_trade_no")]
         [System.Text.Json.Serialization.JsonPropertyName("out_trade_no")]
-        public string OutTradeNumber { get; set; } = string.Empty;
+        public string? OutTradeNumber { get; set; }
+
+        /// <summary>
+        /// 获取或设置微信订单号。与字段 <see cref="OutTradeNumber"/> 二选一。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("transaction_id")]
+        [System.Text.Json.Serialization.JsonPropertyName("transaction_id")]
+        public string? TransactionId { get; set; }
     }
 }


### PR DESCRIPTION
为 `SKIT.FlurlHttpClient.Wechat.TenpayV2.Models.ReversePayOrderRequest` 提供 `TransactionId` 属性，调整 `OutTradeNumber` 属性为 `string?`。 

关联的 ISSUE： #64 