### PR TITLE
fix #67

### DIFF
--- a/src/SKIT.FlurlHttpClient.Wechat.Api/Events/OpenComponent/NotifyThirdFastRegisterEvent.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.Api/Events/OpenComponent/NotifyThirdFastRegisterEvent.cs
@@ -44,7 +44,7 @@ namespace SKIT.FlurlHttpClient.Wechat.Api.Events
                 /// <summary>
                 /// 获取或设置用户姓名。
                 /// </summary>
-                [System.Xml.Serialization.XmlElement("legal_persona_wechat", IsNullable = true)]
+                [System.Xml.Serialization.XmlElement("idname", IsNullable = true)]
                 public string? IdName { get; set; }
 
                 /// <summary>


### PR DESCRIPTION
修复推送事件字段命名错误
https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/register-management/fast-registration-ind/fastRegisterPersonalMp.html