### PR TITLE
fix #69

### DIFF
--- a/docs/WechatApi/Advanced_EventDataDeserialization.md
+++ b/docs/WechatApi/Advanced_EventDataDeserialization.md
@@ -44,7 +44,7 @@ switch (msgType)
             var callbackModel = client.DeserializeEventFromXml<Events.TextMessageEvent>(callbackXml);
         }
         break;
-    // 省略其他情况
+    // 其他情况略
 }
 ```
 

--- a/docs/WechatTenpayV3/Advanced_RequestSensitiveDataEncryption.md
+++ b/docs/WechatTenpayV3/Advanced_RequestSensitiveDataEncryption.md
@@ -164,6 +164,7 @@ public class RedisCertificateManager : CertificateManager
 
         IDictionary<string, string> map = values.ToDictionary(k => k.Name.ToString(), v => v.Value.ToString());
         return new CertificateEntry(
+            algorithmType: map[nameof(CertificateEntry.AlgorithmType)],
             serialNumber: map[nameof(CertificateEntry.SerialNumber)],
             certificate: map[nameof(CertificateEntry.Certificate)],
             effectiveTime: DateTimeOffset.Parse(map[nameof(CertificateEntry.EffectiveTime)]),
@@ -175,6 +176,7 @@ public class RedisCertificateManager : CertificateManager
     {
         return new HashEntry[]
         {
+            new HashEntry(nameof(CertificateEntry.AlgorithmType), entry.AlgorithmType),
             new HashEntry(nameof(CertificateEntry.SerialNumber), entry.SerialNumber),
             new HashEntry(nameof(CertificateEntry.Certificate), entry.Certificate),
             new HashEntry(nameof(CertificateEntry.EffectiveTime), entry.EffectiveTime.ToString()),

--- a/docs/WechatTenpayV3/Advanced_SMAlgorithm.md
+++ b/docs/WechatTenpayV3/Advanced_SMAlgorithm.md
@@ -1,0 +1,37 @@
+﻿## 如何接入国密算法？
+
+---
+
+> 请先自行阅读：
+>
+> [《微信支付开发者文档 - 国密接入指引》](https://pay.weixin.qq.com/docs/merchant/development/shangmi/introduction.html)
+
+从 v2.14.0 版本起，本库支持接入微信支付平台基于国密证书和使用 SM2/SM3/SM4 算法的 API v3 接口。
+
+---
+
+### 接入指引
+
+在微信商户平台开通国密接入权限后，你需要在原有的项目代码基础上做出如下两点调整。
+
+首先，构造得到 `WechatTenpayClient` 对象的方式与原有方式基本一致，只需将 `MerchantCertificateSerialNumber`、`MerchantCertificatePrivateKey` 替换为相应的国密证书内容即可，并指定签名认证方式：
+
+```csharp
+var options = new WechatTenpayClientOptions()
+{
+    // 其他配置项略
+    SignScheme = Constants.SignSchemes.WECHATPAY2_SM2_WITH_SM3
+};
+var client = new WechatTenpayClient(options);
+```
+
+此外，获取平台证书并存入平台证书管理器 `PlatformCertificateManager` 时，需指定证书的算法类型：
+
+```csharp
+// 如果是 RSA 证书
+manager.AddEntry(new CertificateEntry("RSA", "RSA 证书序列号", "RSA 证书内容", "RSA 证书生效时间", "RSA 证书过期时间"));
+// 如果是 SM2 证书
+manager.AddEntry(new CertificateEntry("SM2", "SM2 证书序列号", "SM2 证书内容", "SM2 证书生效时间", "SM2 证书过期时间"));
+```
+
+这样，就已经完成了接入国密算法的全部流程。请求自动签名、响应验证签名、加解密敏感数据字段、解析回调通知事件模型等相关的扩展方法调用方式与原有方式完全一致。

--- a/docs/WechatTenpayV3/README.md
+++ b/docs/WechatTenpayV3/README.md
@@ -12,9 +12,9 @@
 
 -   支持直连商户、服务商两种模式。
 
--   请求时自动生成签名，无需开发者手动干预。
+-   请求时自动生成签名（同时支持国际 RSA 算法或国密 SM 算法），无需开发者手动干预。
 
--   提供了微信支付所需的 RSA、AES、SHA-256 等算法工具类。
+-   提供了微信支付所需的 RSA、AES、SM2/SM3/SM4、SHA-256 等算法工具类。
 
 -   提供了生成调起支付签名、加密请求中敏感数据、解密响应中敏感数据、解析回调通知事件敏感数据等扩展方法。
 
@@ -113,6 +113,8 @@ else
 -   [如何验证回调通知事件签名？](./Advanced_EventSignatureVerification.md)
 
 -   [如何生成客户端调起支付时所需的参数及签名？](./Advanced_Parameters.md)
+
+-   [如何接入国密算法？](./Advanced_SMAlgorithm.md)
 
 -   [如何扩展额外的 API？](./Advanced_Extensions.md)
 

--- a/docs/WechatWork/Advanced_EventDataDeserialization.md
+++ b/docs/WechatWork/Advanced_EventDataDeserialization.md
@@ -35,7 +35,7 @@ switch (msgType)
             var callbackModel = client.DeserializeEventFromXml<Events.TextMessageEvent>(callbackXml);
         }
         break;
-    // 省略其他情况
+    // 其他情况略
 }
 ```
 

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Extensions/Platform/WechatOpenAIPlatformClientExecuteQueryExtensions.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Extensions/Platform/WechatOpenAIPlatformClientExecuteQueryExtensions.cs
@@ -10,7 +10,7 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI
     {
         /// <summary>
         /// <para>异步调用 [POST] /sign/{TOKEN} 接口。</para>
-        /// <para>REF: https://developers.weixin.qq.com/doc/aispeech/platform/INTERFACEDOCUMENT.html </para>
+        /// <para>REF: https://developers.weixin.qq.com/doc/aispeech/confapi/INTERFACEDOCUMENT.html#_1-%E8%8E%B7%E5%8F%96signature%E6%8E%A5%E5%8F%A3 </para>
         /// </summary>
         /// <param name="client"></param>
         /// <param name="request"></param>
@@ -29,7 +29,7 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI
 
         /// <summary>
         /// <para>异步调用 [POST] /aibot/{TOKEN} 接口。</para>
-        /// <para>REF: https://developers.weixin.qq.com/doc/aispeech/platform/INTERFACEDOCUMENT.html </para>
+        /// <para>REF: https://developers.weixin.qq.com/doc/aispeech/confapi/INTERFACEDOCUMENT.html#_2-%E6%99%BA%E8%83%BD%E5%AF%B9%E8%AF%9D%E6%8E%A5%E5%8F%A3 </para>
         /// </summary>
         /// <param name="client"></param>
         /// <param name="request"></param>

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+﻿using System.Text.Json.Serialization;
+using System.Xml.Serialization;
 
 namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
 {
@@ -6,7 +7,7 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
     /// <para>表示 [POST] /aibot/{TOKEN} 接口的请求。</para>
     /// </summary>
     [XmlRoot("xml")]
-    public class AIBotRequest : WechatOpenAIPlatformRequest, WechatOpenAIPlatformRequest.Serialization.IEncryptedXmlable
+    public class AIBotRequest : WechatOpenAIPlatformRequest
     {
         /// <summary>
         /// 获取或设置请求签名。

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotRequest.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using System.Xml.Serialization;
+using System.Collections.Generic;
 
 namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
 {
@@ -12,22 +11,36 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
         /// <summary>
         /// 获取或设置请求签名。
         /// </summary>
-        [XmlElement("signature")]
-        [JsonPropertyName("signature")]
+        [Newtonsoft.Json.JsonProperty("signature")]
+        [System.Text.Json.Serialization.JsonPropertyName("signature")]
         public string Signature { get; set; } = string.Empty;
 
         /// <summary>
         /// 获取或设置询问语句。
         /// </summary>
-        [XmlElement("query")]
-        [JsonPropertyName("query")]
+        [Newtonsoft.Json.JsonProperty("query")]
+        [System.Text.Json.Serialization.JsonPropertyName("query")]
         public string QueryString { get; set; } = string.Empty;
 
         /// <summary>
         /// 获取或设置环境。
         /// </summary>
-        [XmlElement("env", IsNullable = true)]
-        [JsonPropertyName("env")]
+        [Newtonsoft.Json.JsonProperty("env")]
+        [System.Text.Json.Serialization.JsonPropertyName("env")]
         public string? Environment { get; set; }
+
+        /// <summary>
+        /// 获取或设置第一优先级的限定技能命中范围列表。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("first_priority_skills")]
+        [System.Text.Json.Serialization.JsonPropertyName("first_priority_skills")]
+        public IList<string>? FirstPrioritySkillList { get; set; }
+
+        /// <summary>
+        /// 获取或设置第二优先级的限定技能命中范围列表。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("second_priority_skills")]
+        [System.Text.Json.Serialization.JsonPropertyName("second_priority_skills")]
+        public IList<string>? SecondPrioritySkillList { get; set; }
     }
 }

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotRequest.cs
@@ -5,7 +5,6 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
     /// <summary>
     /// <para>表示 [POST] /aibot/{TOKEN} 接口的请求。</para>
     /// </summary>
-    [XmlRoot("xml")]
     public class AIBotRequest : WechatOpenAIPlatformRequest
     {
         /// <summary>

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotRequest.cs
@@ -13,18 +13,21 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
         /// 获取或设置请求签名。
         /// </summary>
         [XmlElement("signature")]
+        [JsonPropertyName("signature")]
         public string Signature { get; set; } = string.Empty;
 
         /// <summary>
         /// 获取或设置询问语句。
         /// </summary>
         [XmlElement("query")]
+        [JsonPropertyName("query")]
         public string QueryString { get; set; } = string.Empty;
 
         /// <summary>
         /// 获取或设置环境。
         /// </summary>
         [XmlElement("env", IsNullable = true)]
+        [JsonPropertyName("env")]
         public string? Environment { get; set; }
     }
 }

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotResponse.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotResponse.cs
@@ -1,92 +1,46 @@
-﻿namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
+﻿using System;
+
+namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
 {
     /// <summary>
     /// <para>表示 [POST] /aibot/{TOKEN} 接口的响应。</para>
     /// </summary>
-    public class AIBotResponse : WechatOpenAIPlatformResponse<AIBotResponse.Types.Data>
+    public class AIBotResponse : WechatOpenAIPlatformResponse
     {
         public static class Types
         {
-            public class Data
+            public class BotState
             {
-                public static class Types
-                {
-                    public class BotState
-                    {
-                        /// <summary>
-                        /// 获取或设置机器人配置错误信息。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("err_msg")]
-                        [System.Text.Json.Serialization.JsonPropertyName("err_msg")]
-                        public string? ErrorMessage { get; set; }
+                /// <summary>
+                /// 获取或设置机器人配置错误信息。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("err_msg")]
+                [System.Text.Json.Serialization.JsonPropertyName("err_msg")]
+                public string? ErrorMessage { get; set; }
 
-                        /// <summary>
-                        /// 获取或设置最后有效时间字符串。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("latest_time")]
-                        [System.Text.Json.Serialization.JsonPropertyName("latest_time")]
-                        public string? LatestTimeString { get; set; }
+                /// <summary>
+                /// 获取或设置最后有效时间字符串。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("latest_time")]
+                [System.Text.Json.Serialization.JsonPropertyName("latest_time")]
+                public string? LatestTimeString { get; set; }
 
-                        /// <summary>
-                        /// 获取或设置最后有效时间字符串。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("latest_valid")]
-                        [System.Text.Json.Serialization.JsonPropertyName("latest_valid")]
-                        public bool IsLatestValid { get; set; }
-                    }
+                /// <summary>
+                /// 获取或设置最后有效时间字符串。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("latest_valid")]
+                [System.Text.Json.Serialization.JsonPropertyName("latest_valid")]
+                public bool IsLatestValid { get; set; }
+            }
 
-                    public class Message
-                    {
-                        /// <summary>
-                        /// 获取或设置技能 ID。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("ans_node_id")]
-                        [System.Text.Json.Serialization.JsonPropertyName("ans_node_id")]
-                        public int AnswerNodeId { get; set; }
-
-                        /// <summary>
-                        /// 获取或设置技能名称。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("ans_node_name")]
-                        [System.Text.Json.Serialization.JsonPropertyName("ans_node_name")]
-                        public string AnswerNodeName { get; set; } = default!;
-
-                        /// <summary>
-                        /// 获取或设置置信度。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("confidence")]
-                        [System.Text.Json.Serialization.JsonPropertyName("confidence")]
-                        public int Confidence { get; set; } = default!;
-
-                        /// <summary>
-                        /// 获取或设置消息类型。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("msg_type")]
-                        [System.Text.Json.Serialization.JsonPropertyName("msg_type")]
-                        public string MessageType { get; set; } = default!;
-
-                        /// <summary>
-                        /// 获取或设置消息内容。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("content")]
-                        [System.Text.Json.Serialization.JsonPropertyName("content")]
-                        public string Content { get; set; } = default!;
-
-                        /// <summary>
-                        /// 获取或设置消息状态。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("status")]
-                        [System.Text.Json.Serialization.JsonPropertyName("status")]
-                        public string Status { get; set; } = default!;
-
-                        /// <summary>
-                        /// 获取或设置窗口标题。
-                        /// </summary>
-                        [Newtonsoft.Json.JsonProperty("resp_title")]
-                        [System.Text.Json.Serialization.JsonPropertyName("resp_title")]
-                        public string? ResponseTitle { get; set; }
-                    }
-                }
+            public class Message
+            {
+                /// <summary>
+                /// 获取或设置技能 ID。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("ans_node_id")]
+                [System.Text.Json.Serialization.JsonPropertyName("ans_node_id")]
+                public int AnswerNodeId { get; set; }
 
                 /// <summary>
                 /// 获取或设置技能名称。
@@ -96,61 +50,164 @@
                 public string AnswerNodeName { get; set; } = default!;
 
                 /// <summary>
-                /// 获取或设置回复类型。
+                /// 获取或设置置信度。
                 /// </summary>
-                [Newtonsoft.Json.JsonProperty("answer_type")]
-                [System.Text.Json.Serialization.JsonPropertyName("answer_type")]
-                public string AnswerType { get; set; } = default!;
+                [Newtonsoft.Json.JsonProperty("confidence")]
+                [System.Text.Json.Serialization.JsonPropertyName("confidence")]
+                public float Confidence { get; set; } = default!;
 
                 /// <summary>
-                /// 获取或设置回复内容。
+                /// 获取或设置消息类型。
                 /// </summary>
-                [Newtonsoft.Json.JsonProperty("answer")]
-                [System.Text.Json.Serialization.JsonPropertyName("answer")]
-                public string Answer { get; set; } = default!;
+                [Newtonsoft.Json.JsonProperty("msg_type")]
+                [System.Text.Json.Serialization.JsonPropertyName("msg_type")]
+                public string MessageType { get; set; } = default!;
 
                 /// <summary>
-                /// 获取或设置意图标题。
+                /// 获取或设置消息内容。
                 /// </summary>
-                [Newtonsoft.Json.JsonProperty("title")]
-                [System.Text.Json.Serialization.JsonPropertyName("title")]
-                public string Title { get; set; } = default!;
+                [Newtonsoft.Json.JsonProperty("content")]
+                [System.Text.Json.Serialization.JsonPropertyName("content")]
+                public string Content { get; set; } = default!;
 
                 /// <summary>
-                /// 获取或设置回复状态。
+                /// 获取或设置消息状态。
                 /// </summary>
                 [Newtonsoft.Json.JsonProperty("status")]
                 [System.Text.Json.Serialization.JsonPropertyName("status")]
                 public string Status { get; set; } = default!;
 
                 /// <summary>
-                /// 获取或设置发起用户。
+                /// 获取或设置窗口标题。
                 /// </summary>
-                [Newtonsoft.Json.JsonProperty("from_user_name")]
-                [System.Text.Json.Serialization.JsonPropertyName("from_user_name")]
-                public string FromUserName { get; set; } = default!;
+                [Newtonsoft.Json.JsonProperty("resp_title")]
+                [System.Text.Json.Serialization.JsonPropertyName("resp_title")]
+                public string? ResponseTitle { get; set; }
+            }
+
+            /// <summary>
+            /// 推荐问题
+            /// </summary>
+            public class Option
+            {
+                /// <summary>
+                /// 推荐的分类。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("ans_node_name")]
+                [System.Text.Json.Serialization.JsonPropertyName("ans_node_name")]
+                public string AnswerNodeName { get; set; } = default!;
 
                 /// <summary>
-                /// 获取或设置接收机器人。
+                /// 推荐标准问题。
                 /// </summary>
-                [Newtonsoft.Json.JsonProperty("to_user_name")]
-                [System.Text.Json.Serialization.JsonPropertyName("to_user_name")]
-                public string ToUserName { get; set; } = default!;
+                [Newtonsoft.Json.JsonProperty("title")]
+                [System.Text.Json.Serialization.JsonPropertyName("title")]
+                public string Title { get; set; } = default!;
 
                 /// <summary>
-                /// 获取或设置机器人状态信息。
+                /// 推荐回答。
                 /// </summary>
-                [Newtonsoft.Json.JsonProperty("bot_state")]
-                [System.Text.Json.Serialization.JsonPropertyName("bot_state")]
-                public Types.BotState? BotState { get; set; }
+                [Newtonsoft.Json.JsonProperty("answer")]
+                [System.Text.Json.Serialization.JsonPropertyName("answer")]
+                public string Answer { get; set; } = default!;
 
                 /// <summary>
-                /// 获取或设置详细回答列表。
+                /// 推荐信息指数。
                 /// </summary>
-                [Newtonsoft.Json.JsonProperty("msg")]
-                [System.Text.Json.Serialization.JsonPropertyName("msg")]
-                public Types.Message[] MessageList { get; set; } = default!;
+                [Newtonsoft.Json.JsonProperty("confidence")]
+                [System.Text.Json.Serialization.JsonPropertyName("confidence")]
+                public float Confidence { get; set; } = default!;
             }
         }
+
+        /// <summary>
+        /// 技能id。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("ans_node_id")]
+        [System.Text.Json.Serialization.JsonPropertyName("ans_node_id")]
+        public int AnswerNodeId { get; set; }
+
+        /// <summary>
+        /// 分类/技能名称。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("ans_node_name")]
+        [System.Text.Json.Serialization.JsonPropertyName("ans_node_name")]
+        public string AnswerNodeName { get; set; } = default!;
+
+        /// <summary>
+        /// 标准问题/意图名称。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("title")]
+        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        public string Title { get; set; } = default!;
+
+        /// <summary>
+        /// 命中的回答。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("answer")]
+        [System.Text.Json.Serialization.JsonPropertyName("answer")]
+        public string Answer { get; set; } = default!;
+
+        /// <summary>
+        /// 回答的类型。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("answer_type")]
+        [System.Text.Json.Serialization.JsonPropertyName("answer_type")]
+        public string AnswerType { get; set; } = default!;
+
+        /// <summary>
+        /// 回答详细信息(已废弃)。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("msg")]
+        [System.Text.Json.Serialization.JsonPropertyName("msg")]
+        [Obsolete("已废弃")]
+        public Types.Message[] MessageList { get; set; } = default!;
+
+        /// <summary>
+        /// 回答信心指数。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("confidence")]
+        [System.Text.Json.Serialization.JsonPropertyName("confidence")]
+        public float Confidence { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("options")]
+        [System.Text.Json.Serialization.JsonPropertyName("options")]
+        public Types.Option[] Options { get; set; } = default!;
+
+        /// <summary>
+        /// 发起 query 的用户,对应签名接口的userid。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("from_user_name")]
+        [System.Text.Json.Serialization.JsonPropertyName("from_user_name")]
+        public string FromUserName { get; set; } = default!;
+
+        /// <summary>
+        /// 接受 query 的机器人。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("to_user_name")]
+        [System.Text.Json.Serialization.JsonPropertyName("to_user_name")]
+        public string ToUserName { get; set; } = default!;
+
+        /// <summary>
+        /// 机器人回复的状态, 可能的数值：FAQ、NOMATCH、CONTEXT_FAQ、GENERAL_FAQ、FAQ_RECOMMEND。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("status")]
+        [System.Text.Json.Serialization.JsonPropertyName("status")]
+        public string Status { get; set; } = default!;
+
+        /// <summary>
+        /// 消息id
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("msg_id")]
+        [System.Text.Json.Serialization.JsonPropertyName("msg_id")]
+        public string MessageId { get; set; } = default!;
+
+
+        /// <summary>
+        /// 用户发送的消息
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("query")]
+        [System.Text.Json.Serialization.JsonPropertyName("query")]
+        public string Query { get; set; } = default!;
     }
 }

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotResponse.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/AIBotResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
 {
@@ -40,6 +40,7 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
                 /// </summary>
                 [Newtonsoft.Json.JsonProperty("ans_node_id")]
                 [System.Text.Json.Serialization.JsonPropertyName("ans_node_id")]
+                [System.Text.Json.Serialization.JsonNumberHandling(System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString)]
                 public int AnswerNodeId { get; set; }
 
                 /// <summary>
@@ -78,136 +79,349 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
                 public string Status { get; set; } = default!;
 
                 /// <summary>
+                /// 获取或设置是否是列表选择。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("list_options")]
+                [System.Text.Json.Serialization.JsonPropertyName("list_options")]
+                public bool IsListOptions { get; set; }
+
+                /// <summary>
+                /// 获取或设置是否仅选择。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("take_options_only")]
+                [System.Text.Json.Serialization.JsonPropertyName("take_options_only")]
+                public bool IsTakeOptionsOnly { get; set; }
+
+                /// <summary>
+                /// 获取或设置当前事件。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("event")]
+                [System.Text.Json.Serialization.JsonPropertyName("event")]
+                public string? Event { get; set; }
+
+                /// <summary>
+                /// 获取或设置调试信息。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("debug_info")]
+                [System.Text.Json.Serialization.JsonPropertyName("debug_info")]
+                public string? DebugInfo { get; set; }
+
+                /// <summary>
                 /// 获取或设置窗口标题。
                 /// </summary>
                 [Newtonsoft.Json.JsonProperty("resp_title")]
                 [System.Text.Json.Serialization.JsonPropertyName("resp_title")]
                 public string? ResponseTitle { get; set; }
+
+                /// <summary>
+                /// 获取或设置场景状态。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("scene_status")]
+                [System.Text.Json.Serialization.JsonPropertyName("scene_status")]
+                public string? SceneStatus { get; set; }
+
+                /// <summary>
+                /// 获取或设置会话 ID。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("session_id")]
+                [System.Text.Json.Serialization.JsonPropertyName("session_id")]
+                public string? SessionId { get; set; }
             }
 
-            /// <summary>
-            /// 推荐问题
-            /// </summary>
             public class Option
             {
                 /// <summary>
-                /// 推荐的分类。
+                /// 获取或设置推荐分类。
                 /// </summary>
                 [Newtonsoft.Json.JsonProperty("ans_node_name")]
                 [System.Text.Json.Serialization.JsonPropertyName("ans_node_name")]
                 public string AnswerNodeName { get; set; } = default!;
 
                 /// <summary>
-                /// 推荐标准问题。
+                /// 获取或设置推荐标准问题。
                 /// </summary>
                 [Newtonsoft.Json.JsonProperty("title")]
                 [System.Text.Json.Serialization.JsonPropertyName("title")]
                 public string Title { get; set; } = default!;
 
                 /// <summary>
-                /// 推荐回答。
+                /// 获取或设置推荐回答。
                 /// </summary>
                 [Newtonsoft.Json.JsonProperty("answer")]
                 [System.Text.Json.Serialization.JsonPropertyName("answer")]
                 public string Answer { get; set; } = default!;
 
                 /// <summary>
-                /// 推荐信息指数。
+                /// 获取或设置推荐信息指数。
                 /// </summary>
                 [Newtonsoft.Json.JsonProperty("confidence")]
                 [System.Text.Json.Serialization.JsonPropertyName("confidence")]
-                public float Confidence { get; set; } = default!;
+                public double Confidence { get; set; }
+            }
+
+            public class Slot
+            {
+                /// <summary>
+                /// 获取或设置槽位确认状态。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("confirm_status")]
+                [System.Text.Json.Serialization.JsonPropertyName("confirm_status")]
+                public string ConfirmStatus { get; set; } = default!;
+
+                /// <summary>
+                /// 获取或设置开始位置。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("start")]
+                [System.Text.Json.Serialization.JsonPropertyName("start")]
+                public int Start { get; set; }
+
+                /// <summary>
+                /// 获取或设置结束位置。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("end")]
+                [System.Text.Json.Serialization.JsonPropertyName("end")]
+                public int End { get; set; }
+
+                /// <summary>
+                /// 获取或设置槽位名称。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("slot_name")]
+                [System.Text.Json.Serialization.JsonPropertyName("slot_name")]
+                public string SlotName { get; set; } = default!;
+
+                /// <summary>
+                /// 获取或设置槽位值。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("slot_value")]
+                [System.Text.Json.Serialization.JsonPropertyName("slot_value")]
+                public string SlotValue { get; set; } = default!;
+
+                /// <summary>
+                /// 获取或设置词典类型。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("entity_type")]
+                [System.Text.Json.Serialization.JsonPropertyName("entity_type")]
+                public string? EntityType { get; set; }
+
+                /// <summary>
+                /// 获取或设置归一化的值。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("norm")]
+                [System.Text.Json.Serialization.JsonPropertyName("norm")]
+                public string? Norm { get; set; }
+
+                /// <summary>
+                /// 获取或设置归一化的值详细信息。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("norm_detail")]
+                [System.Text.Json.Serialization.JsonPropertyName("norm_detail")]
+                public string? NormDetail { get; set; }
+
+                /// <summary>
+                /// 获取或设置回复的意图名称。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("title")]
+                [System.Text.Json.Serialization.JsonPropertyName("title")]
+                public string? Title { get; set; }
             }
         }
 
         /// <summary>
-        /// 技能id。
+        /// 获取或设置技能 ID。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("ans_node_id")]
         [System.Text.Json.Serialization.JsonPropertyName("ans_node_id")]
+        [System.Text.Json.Serialization.JsonNumberHandling(System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString)]
         public int AnswerNodeId { get; set; }
 
         /// <summary>
-        /// 分类/技能名称。
+        /// 获取或设置技能名称。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("ans_node_name")]
         [System.Text.Json.Serialization.JsonPropertyName("ans_node_name")]
         public string AnswerNodeName { get; set; } = default!;
 
         /// <summary>
-        /// 标准问题/意图名称。
+        /// 获取或设置标准问题或意图名称。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("title")]
         [System.Text.Json.Serialization.JsonPropertyName("title")]
         public string Title { get; set; } = default!;
 
         /// <summary>
-        /// 命中的回答。
+        /// 获取或设置命中的回答。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("answer")]
         [System.Text.Json.Serialization.JsonPropertyName("answer")]
         public string Answer { get; set; } = default!;
 
         /// <summary>
-        /// 回答的类型。
+        /// 获取或设置回答显示状态。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("answer_open")]
+        [System.Text.Json.Serialization.JsonPropertyName("answer_open")]
+        public int? AnswerOpenStatus { get; set; }
+
+        /// <summary>
+        /// 获取或设置回答的类型。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("answer_type")]
         [System.Text.Json.Serialization.JsonPropertyName("answer_type")]
         public string AnswerType { get; set; } = default!;
 
         /// <summary>
-        /// 回答详细信息(已废弃)。
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("msg")]
-        [System.Text.Json.Serialization.JsonPropertyName("msg")]
-        [Obsolete("已废弃")]
-        public Types.Message[] MessageList { get; set; } = default!;
-
-        /// <summary>
-        /// 回答信心指数。
+        /// 获取或设置回答信心指数。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("confidence")]
         [System.Text.Json.Serialization.JsonPropertyName("confidence")]
-        public float Confidence { get; set; } = default!;
-
-        [Newtonsoft.Json.JsonProperty("options")]
-        [System.Text.Json.Serialization.JsonPropertyName("options")]
-        public Types.Option[] Options { get; set; } = default!;
+        public double Confidence { get; set; }
 
         /// <summary>
-        /// 发起 query 的用户,对应签名接口的userid。
+        /// 获取或设置发起查询的用户 ID。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("from_user_name")]
         [System.Text.Json.Serialization.JsonPropertyName("from_user_name")]
         public string FromUserName { get; set; } = default!;
 
         /// <summary>
-        /// 接受 query 的机器人。
+        /// 获取或设置接受查询的机器人。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("to_user_name")]
         [System.Text.Json.Serialization.JsonPropertyName("to_user_name")]
         public string ToUserName { get; set; } = default!;
 
         /// <summary>
-        /// 机器人回复的状态, 可能的数值：FAQ、NOMATCH、CONTEXT_FAQ、GENERAL_FAQ、FAQ_RECOMMEND。
+        /// 获取或设置用户发送的消息。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("query")]
+        [System.Text.Json.Serialization.JsonPropertyName("query")]
+        public string QueryString { get; set; } = default!;
+
+        /// <summary>
+        /// 获取或设置消息 ID。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("msg_id")]
+        [System.Text.Json.Serialization.JsonPropertyName("msg_id")]
+        public string MessageId { get; set; } = default!;
+
+        /// <summary>
+        /// 获取或设置消息类型。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("msgtype")]
+        [System.Text.Json.Serialization.JsonPropertyName("msgtype")]
+        public string MessageType { get; set; } = default!;
+
+        /// <summary>
+        /// 获取或设置回答详细信息。
+        /// </summary>
+        [Obsolete("相关接口或字段于 2022-04-15 下线。")]
+        [Newtonsoft.Json.JsonProperty("msg")]
+        [System.Text.Json.Serialization.JsonPropertyName("msg")]
+        public Types.Message[]? MessageList { get; set; }
+
+        /// <summary>
+        /// 获取或设置机器人回复的状态。
         /// </summary>
         [Newtonsoft.Json.JsonProperty("status")]
         [System.Text.Json.Serialization.JsonPropertyName("status")]
         public string Status { get; set; } = default!;
 
         /// <summary>
-        /// 消息id
+        /// 获取或设置当前事件。
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("msg_id")]
-        [System.Text.Json.Serialization.JsonPropertyName("msg_id")]
-        public string MessageId { get; set; } = default!;
-
+        [Newtonsoft.Json.JsonProperty("event")]
+        [System.Text.Json.Serialization.JsonPropertyName("event")]
+        public string? Event { get; set; }
 
         /// <summary>
-        /// 用户发送的消息
+        /// 获取或设置会话 ID。
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("query")]
-        [System.Text.Json.Serialization.JsonPropertyName("query")]
-        public string Query { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("session_id")]
+        [System.Text.Json.Serialization.JsonPropertyName("session_id")]
+        public string? SessionId { get; set; }
+
+        /// <summary>
+        /// 获取或设置请求标识符。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("rid")]
+        [System.Text.Json.Serialization.JsonPropertyName("rid")]
+        public string? RequestId { get; set; }
+
+        /// <summary>
+        /// 获取或设置当前对话会话状态。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("dialog_session_status")]
+        [System.Text.Json.Serialization.JsonPropertyName("dialog_session_status")]
+        public string? DialogSessionStatus { get; set; }
+
+        /// <summary>
+        /// 获取或设置当前对话状态。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("dialog_status")]
+        [System.Text.Json.Serialization.JsonPropertyName("dialog_status")]
+        public string? DialogStatus { get; set; }
+
+        /// <summary>
+        /// 获取或设置意图确认状态。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("intent_confirm_status")]
+        [System.Text.Json.Serialization.JsonPropertyName("intent_confirm_status")]
+        public string? IntentConfirmStatus { get; set; }
+
+        /// <summary>
+        /// 获取或设置场景状态。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("scene_status")]
+        [System.Text.Json.Serialization.JsonPropertyName("scene_status")]
+        public string? SceneStatus { get; set; }
+
+        /// <summary>
+        /// 获取或设置技能 ID。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("skill_id")]
+        [System.Text.Json.Serialization.JsonPropertyName("skill_id")]
+        public string? SkillId { get; set; }
+
+        /// <summary>
+        /// 获取或设置技能名称。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("skill_name")]
+        [System.Text.Json.Serialization.JsonPropertyName("skill_name")]
+        public string? SkillName { get; set; }
+
+        /// <summary>
+        /// 获取或设置机器人回复的状态。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("is_default_answer")]
+        [System.Text.Json.Serialization.JsonPropertyName("is_default_answer")]
+        public bool IsDefaultAnswer { get; set; }
+
+        /// <summary>
+        /// 获取或设置是否是列表选择。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("list_options")]
+        [System.Text.Json.Serialization.JsonPropertyName("list_options")]
+        public bool IsListOptions { get; set; }
+
+        /// <summary>
+        /// 获取或设置是否仅选择。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("take_options_only")]
+        [System.Text.Json.Serialization.JsonPropertyName("take_options_only")]
+        public bool IsTakeOptionsOnly { get; set; }
+
+        /// <summary>
+        /// 获取或设置推荐问题列表。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("options")]
+        [System.Text.Json.Serialization.JsonPropertyName("options")]
+        public Types.Option[]? OptionList { get; set; }
+
+        /// <summary>
+        /// 获取或设置槽位列表。
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("slots_info")]
+        [System.Text.Json.Serialization.JsonPropertyName("slots_info")]
+        public Types.Slot[]? SlotList { get; set; }
     }
 }

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/SignRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/SignRequest.cs
@@ -13,18 +13,21 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
         /// 获取或设置用户 ID。
         /// </summary>
         [XmlElement("userid")]
+        [JsonPropertyName("userid")]
         public string UserId { get; set; } = string.Empty;
 
         /// <summary>
         /// 获取或设置用户昵称。
         /// </summary>
         [XmlElement("username")]
+        [JsonPropertyName("username")]
         public string Nickname { get; set; } = string.Empty;
 
         /// <summary>
         /// 获取或设置用户头像 URL。
         /// </summary>
         [XmlElement("avatar", IsNullable = true)]
+        [JsonPropertyName("avatar")]
         public string? AvatarUrl { get; set; }
     }
 }

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/SignRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/SignRequest.cs
@@ -1,33 +1,29 @@
-﻿using System.Text.Json.Serialization;
-using System.Xml.Serialization;
-
 namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
 {
     /// <summary>
     /// <para>表示 [POST] /sign/{TOKEN} 接口的请求。</para>
     /// </summary>
-    [XmlRoot("xml")]
     public class SignRequest : WechatOpenAIPlatformRequest
     {
         /// <summary>
         /// 获取或设置用户 ID。
         /// </summary>
-        [XmlElement("userid")]
-        [JsonPropertyName("userid")]
+        [Newtonsoft.Json.JsonProperty("userid")]
+        [System.Text.Json.Serialization.JsonPropertyName("userid")]
         public string UserId { get; set; } = string.Empty;
 
         /// <summary>
         /// 获取或设置用户昵称。
         /// </summary>
-        [XmlElement("username")]
-        [JsonPropertyName("username")]
-        public string Nickname { get; set; } = string.Empty;
+        [Newtonsoft.Json.JsonProperty("username")]
+        [System.Text.Json.Serialization.JsonPropertyName("username")]
+        public string? Nickname { get; set; }
 
         /// <summary>
         /// 获取或设置用户头像 URL。
         /// </summary>
-        [XmlElement("avatar", IsNullable = true)]
-        [JsonPropertyName("avatar")]
+        [Newtonsoft.Json.JsonProperty("avatar")]
+        [System.Text.Json.Serialization.JsonPropertyName("avatar")]
         public string? AvatarUrl { get; set; }
     }
 }

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/SignRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/Models/Platform/Query/SignRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+﻿using System.Text.Json.Serialization;
+using System.Xml.Serialization;
 
 namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
 {
@@ -6,7 +7,7 @@ namespace SKIT.FlurlHttpClient.Wechat.OpenAI.Models.Platform
     /// <para>表示 [POST] /sign/{TOKEN} 接口的请求。</para>
     /// </summary>
     [XmlRoot("xml")]
-    public class SignRequest : WechatOpenAIPlatformRequest, WechatOpenAIPlatformRequest.Serialization.IEncryptedXmlable
+    public class SignRequest : WechatOpenAIPlatformRequest
     {
         /// <summary>
         /// 获取或设置用户 ID。

--- a/src/SKIT.FlurlHttpClient.Wechat.OpenAI/WechatOpenAIPlatformEndpoints.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.OpenAI/WechatOpenAIPlatformEndpoints.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// 主域名（默认）。
         /// </summary>
-        public const string DEFAULT = "https://openai.weixin.qq.com/openai/";
+        public const string DEFAULT = "https://openai.weixin.qq.com/openapi/";
     }
 }

--- a/test/SKIT.FlurlHttpClient.Wechat.TenpayV3.UnitTests/TestCase_CertificateManagerTests.cs
+++ b/test/SKIT.FlurlHttpClient.Wechat.TenpayV3.UnitTests/TestCase_CertificateManagerTests.cs
@@ -5,10 +5,19 @@ namespace SKIT.FlurlHttpClient.Wechat.TenpayV3.UnitTests
 {
     public class TestCase_CertificateManagerTests
     {
+        private const string CERT_RSA_SN = "3050f72e2dce03e7efe49557dd231d176649afbd";
+        private const string CERT_RSA_PEM = "-----BEGIN CERTIFICATE-----\nMIIFRzCCAy8CFDBQ9y4tzgPn7+SVV90jHRdmSa+9MA0GCSqGSIb3DQEBCwUAMGAx\nCzAJBgNVBAYTAkNOMREwDwYDVQQIDAhTaGFuZ2hhaTERMA8GA1UEBwwIU2hhbmdo\nYWkxDTALBgNVBAoMBFNLSVQxDTALBgNVBAsMBFNLSVQxDTALBgNVBAMMBFNLSVQw\nHhcNMjExMTI1MTgzNzQ4WhcNMjExMjI1MTgzNzQ4WjBgMQswCQYDVQQGEwJDTjER\nMA8GA1UECAwIU2hhbmdoYWkxETAPBgNVBAcMCFNoYW5naGFpMQ0wCwYDVQQKDART\nS0lUMQ0wCwYDVQQLDARTS0lUMQ0wCwYDVQQDDARTS0lUMIICIjANBgkqhkiG9w0B\nAQEFAAOCAg8AMIICCgKCAgEA52DszUZzPKPo1d9Hi5Hjlu7OINwADaeXifA4rvmJ\nJaA+jm4DCMwrAMzyS12EiW31xCAF8LZ/xkrFHO5CZgvK87Y+kY9DmhvNX6FVYsn4\nay7KER0zo87zqQjC+njUu1rYuKnio7MYb354PitwQ3SWNv2qTCbCNCXTN9pJXNhl\nCudWCEWrNrYc4/hKz3bqu1DjpY0oHuuKPk/iRr2TTUIAwahNkNQheQNB2a8hL7L2\nOG1Sn1vaDWe+5RJYlMRZ3NgYDTqoy8GMs+6q091MQMDlQ90jtW/JEoM5DUyI8zfQ\nfDLGnU7FuY0rrZ/+6OQT/o7ISf0OR5TISS0lqnDN3vVaph0ftDGRdGqJk2SJAHIo\nxp5gt410rfWS9kpSDFJs3Pvt4rtNZBYvkGD8obSm91brAkoX4+u1Y4p1qZpWJ4LI\nKw8oyeieqlLZtF/VGKOtKxe/IKn8GwoQJLx4dUGFOqM7HPwR9cyjMaC1o3V1NQG+\n1wD9TLtGh3WXUFJRYDmePaSp39GFPupTMlPRbD0RK80B6xv2rYTyYyd8s2LN6P6H\nh/nFIkc1rekIf9JhPy0WKzrXdmnfjSHKPxmz0WSYN8FxKasqcJhncOdhLTzzVEhj\n9xHSI8ejP2fJ4v+ARoD3GURPD9H7KMa7xmzRSAZ8A8LM3uvdJNhbKBwWqvo45ncz\n+7cCAwEAATANBgkqhkiG9w0BAQsFAAOCAgEAVTS6oMfDA3XTwEel0BvaXMCdo7yM\ns5ueM87151eywnPlConYDXeqhfF0OCSBnY2g7Fpmn+YAUoa/L+FNOx/gMC9QV/lP\nHhhAcWpiCRy52RX/IyTDxFD6OqtH0BaBtDTb+QBXZuFypMUkPy6EUYs5Cl9qYepy\nHcgGVomx7tcwWcvI4o/KZtj8hXC5wu/k4Y0GGUriTt8xmnJ+RTRedZ6hzAFVHtXm\n/YIT9Lc1IIYZuHVyCbX/HXwa0E4r8lghwZRg94HUvpbfabNA3obt5auwtJUfW1tK\n2ERgFrtBRBWf9EGb8TstXqksqYZ04U4OjLm/3ZJhSSYKNbriRLlSEzAlHikNVW+t\n6cTh+sasrGt/qNIRMs5PiipwmV/T3z1LbyoiU7fXZ4GqiWBnZARFC9KiPPTzLszh\nBKJGYHaC8wkGb3WfNWFBqVRfFL8kdME+shLB8/ETQ31gIFeudnW1QlujJ7ZSZtwz\nxT3HxzZIIbNEqLFP+d37kmuKjRmI4KWc+pKOUw9BOl4g/TJH6ySljSNs8LSDWwQY\n76Dsnr+ovz8ZVLNUCmedZCyumeJo2tLkJmsPo5GuMnXpL94mhqpCoUS4l4JbJl44\nT2lmqp1Ueoz+Qlkqyt2lj3heTv9bvB7NO9KHTsDy1hhWHOG1QyXzajyWETU+1XdW\nx1hGvYxtpQPLUE8=\n-----END CERTIFICATE-----";
+        private const string CERT_RSA_START_DATE = "2021-11-26 02:37:48";
+        private const string CERT_RSA_END_DATE = "2021-12-26 02:37:48";
+        private const string CERT_SM2_PEM = "-----BEGIN CERTIFICATE-----\nMIICNzCCAdygAwIBAgIJAOWoGwJCnY0IMAoGCCqBHM9VAYN1MGcxCzAJBgNVBAYT\nAkNOMRAwDgYDVQQIDAdCZWlqaW5nMRAwDgYDVQQHDAdIYWlEaWFuMRMwEQYDVQQK\nDApHTUNlcnQub3JnMR8wHQYDVQQDDBZHTUNlcnQgR00gUm9vdCBDQSAtIDAxMB4X\nDTIyMTEwOTEzMTIyMFoXDTIzMTEwOTEzMTIyMFowSzEtMCsGA1UEAwwkU0tJVC5G\nbHVybEh0dHBDbGllbnQuV2VjaGF0LlRlbnBheVYzMQ0wCwYDVQQKDARTS0lUMQsw\nCQYDVQQGEwJDTjBZMBMGByqGSM49AgEGCCqBHM9VAYItA0IABMXP1hZc2zBzreRN\nZgOR9hklE01tw10RDUfj176EXcVoVOvITMENJ3HREQtDPlOfz8i1SXCQEwclYyxI\n2KcTdKqjgYwwgYkwDAYDVR0TAQH/BAIwADALBgNVHQ8EBAMCA/gwLAYJYIZIAYb4\nQgENBB8WHUdNQ2VydC5vcmcgU2lnbmVkIENlcnRpZmljYXRlMB0GA1UdDgQWBBRj\nIhoxmSgP84XT/scjkQNSWylMFTAfBgNVHSMEGDAWgBR/Wl47AIRZKg+YvqEObzmV\nQxBNBzAKBggqgRzPVQGDdQNJADBGAiEAnXykM0qDOWay2EMB6+c6YJ7h4n7Wbju7\nXuT5RkuM/3ICIQDAA3sLba/dQMhmKkCoJl31iZwYKz7NP+0aq6NhWDommQ==\n-----END CERTIFICATE-----";
+        private const string CERT_SM2_SN = "e5a81b02429d8d08";
+        private const string CERT_SM2_START_DATE = "2022-11-09 21:12:20";
+        private const string CERT_SM2_END_DATE = "2023-11-09 21:12:20";
+        
         [Fact(DisplayName = "测试用例：`CertificateEntry` 序列化")]
         public void TestCertificateEntrySerialization()
         {
-            var entry = new Settings.CertificateEntry("RSA", "FAKE SERIAL NUMBER", "-----BEGIN CERTIFICATE-----FAKE CERTIFICATE-----END CERTIFICATE-----", DateTimeOffset.Now, DateTimeOffset.Now);
+            var entry = new Settings.CertificateEntry(Settings.CertificateEntry.ALGORITHM_TYPE_RSA, CERT_RSA_SN, CERT_RSA_PEM, DateTimeOffset.Parse(CERT_RSA_START_DATE), DateTimeOffset.Parse(CERT_RSA_END_DATE));
 
             var serialized1 = Newtonsoft.Json.JsonConvert.SerializeObject(entry);
             var deserialized1 = Newtonsoft.Json.JsonConvert.DeserializeObject<Settings.CertificateEntry>(serialized1);
@@ -27,6 +36,38 @@ namespace SKIT.FlurlHttpClient.Wechat.TenpayV3.UnitTests
             Assert.Equal(entry.Certificate, deserialized2.Certificate);
             Assert.Equal(entry.EffectiveTime, deserialized2.EffectiveTime);
             Assert.Equal(entry.ExpireTime, deserialized2.ExpireTime);
+        }
+
+        [Fact(DisplayName = "测试用例：`CertificateEntry` 构造器")]
+        public void TestCertificateEntryConstructor()
+        {
+            var certRSA = new Settings.CertificateEntry(
+                new Models.QueryCertificatesResponse.Types.Certificate()
+                {
+                    SerialNumber = CERT_RSA_SN,
+                    EncryptCertificate = new Models.QueryCertificatesResponse.Types.Certificate.Types.EncryptCertificate()
+                    {
+                        CipherText = CERT_RSA_PEM
+                    },
+                    EffectiveTime = DateTimeOffset.Parse(CERT_RSA_START_DATE),
+                    ExpireTime = DateTimeOffset.Parse(CERT_RSA_END_DATE)
+                }
+            );
+            Assert.Equal(Settings.CertificateEntry.ALGORITHM_TYPE_RSA, certRSA.AlgorithmType);
+
+            var certSM2 = new Settings.CertificateEntry(
+                new Models.QueryCertificatesResponse.Types.Certificate()
+                {
+                    SerialNumber = CERT_SM2_SN,
+                    EncryptCertificate = new Models.QueryCertificatesResponse.Types.Certificate.Types.EncryptCertificate()
+                    {
+                        CipherText = CERT_SM2_PEM
+                    },
+                    EffectiveTime = DateTimeOffset.Parse(CERT_SM2_START_DATE),
+                    ExpireTime = DateTimeOffset.Parse(CERT_SM2_END_DATE)
+                }
+            );
+            Assert.Equal(Settings.CertificateEntry.ALGORITHM_TYPE_SM2, certSM2.AlgorithmType);
         }
     }
 }


### PR DESCRIPTION
1. 修复AIBot默认请求域名[官方文档](https://developers.weixin.qq.com/doc/aispeech/confapi/INTERFACEDOCUMENT.html)，已修改为`https://openai.weixin.qq.com/openapi`。
2. 移除`SignRequest`, `AIbotRequest`的加密，官方文档中目前已无需加密。
3. 调整`AIBotResponse`结构，[官方文档](https://developers.weixin.qq.com/doc/aispeech/confapi/INTERFACEDOCUMENT.html#_2-%E6%99%BA%E8%83%BD%E5%AF%B9%E8%AF%9D%E6%8E%A5%E5%8F%A3)。
4. 标记`AIBotResponse`中的`msg`字段为**已废弃**，官方文档上标注为**已废弃**，但目前还是会返回。