### PR TITLE
fix:(work) 异步任务结果某些情况下会数值溢出

### DIFF
--- a/src/SKIT.FlurlHttpClient.Wechat.Work/Models/CgibinBatch/CgibinBatchGetResultResponse.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.Work/Models/CgibinBatch/CgibinBatchGetResultResponse.cs
@@ -65,7 +65,7 @@
         /// </summary>
         [Newtonsoft.Json.JsonProperty("total")]
         [System.Text.Json.Serialization.JsonPropertyName("total")]
-        public int TotalCount { get; set; }
+        public long TotalCount { get; set; }
 
         /// <summary>
         /// 获取或设置目前运行百分比。


### PR DESCRIPTION
企业微信/cgi-bin/batch/getresult接口，如果异步任务的结果中存在错误信息时，企业微信端返回的total，是uint的最大值，int类型的TotalCount会出现数值溢出。

<img width="372" alt="image" src="https://github.com/fudiwei/DotNetCore.SKIT.FlurlHttpClient.Wechat/assets/29294137/46d4752c-aff4-46b1-bc16-541ff7d477db">
