### PR TITLE
更新统一下单scene_info值

### DIFF
--- a/src/SKIT.FlurlHttpClient.Wechat.TenpayV2/Models/Pay/CreatePayUnifiedOrderRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.TenpayV2/Models/Pay/CreatePayUnifiedOrderRequest.cs
@@ -127,42 +127,42 @@ namespace SKIT.FlurlHttpClient.Wechat.TenpayV2.Models
                     public class H5Info
                     {
                         /// <summary>
-                        /// 场景类型。
+                        /// 获取或设置场景类型。
                         /// </summary>
                         [Newtonsoft.Json.JsonProperty("type")]
                         [System.Text.Json.Serialization.JsonPropertyName("type")]
-                        public string Type { get; set; } = string.Empty;
+                        public string? Type { get; set; }
 
                         /// <summary>
-                        /// 应用名。
+                        /// 获取或设置应用名。
                         /// </summary>
                         [Newtonsoft.Json.JsonProperty("app_name")]
                         [System.Text.Json.Serialization.JsonPropertyName("app_name")]
                         public string? AppName { get; set; }
 
                         /// <summary>
-                        /// IOS移动应用bundle_id。
+                        /// 获取或设置 iOS 应用包名。
                         /// </summary>
                         [Newtonsoft.Json.JsonProperty("bundle_id")]
                         [System.Text.Json.Serialization.JsonPropertyName("bundle_id")]
                         public string? BundleId { get; set; }
 
                         /// <summary>
-                        /// 安卓移动应用包名。
+                        /// 获取或设置 Android 应用包名。
                         /// </summary>
                         [Newtonsoft.Json.JsonProperty("package_name")]
                         [System.Text.Json.Serialization.JsonPropertyName("package_name")]
                         public string? PackageName { get; set; }
 
                         /// <summary>
-                        /// WAP网站应用-WAP网站URL地址。
+                        /// 获取或设置网站 URL。
                         /// </summary>
                         [Newtonsoft.Json.JsonProperty("wap_url")]
                         [System.Text.Json.Serialization.JsonPropertyName("wap_url")]
                         public string? WapUrl { get; set; }
 
                         /// <summary>
-                        /// WAP网站应用-WAP 网站名。
+                        /// 获取或设置网站名。
                         /// </summary>
                         [Newtonsoft.Json.JsonProperty("wap_name")]
                         [System.Text.Json.Serialization.JsonPropertyName("wap_name")]
@@ -178,7 +178,7 @@ namespace SKIT.FlurlHttpClient.Wechat.TenpayV2.Models
                 public Types.Store? Store { get; set; }
 
                 /// <summary>
-                /// 获取或设置IOS移动应用/安卓移动应用/WAP网站应用。
+                /// 获取或设置移动应用或网站应用信息。
                 /// </summary>
                 [Newtonsoft.Json.JsonProperty("h5_info")]
                 [System.Text.Json.Serialization.JsonPropertyName("h5_info")]

--- a/src/SKIT.FlurlHttpClient.Wechat.TenpayV2/Models/Pay/CreatePayUnifiedOrderRequest.cs
+++ b/src/SKIT.FlurlHttpClient.Wechat.TenpayV2/Models/Pay/CreatePayUnifiedOrderRequest.cs
@@ -123,6 +123,51 @@ namespace SKIT.FlurlHttpClient.Wechat.TenpayV2.Models
                         [System.Text.Json.Serialization.JsonPropertyName("address")]
                         public string? Address { get; set; }
                     }
+                    
+                    public class H5Info
+                    {
+                        /// <summary>
+                        /// 场景类型。
+                        /// </summary>
+                        [Newtonsoft.Json.JsonProperty("type")]
+                        [System.Text.Json.Serialization.JsonPropertyName("type")]
+                        public string Type { get; set; } = string.Empty;
+
+                        /// <summary>
+                        /// 应用名。
+                        /// </summary>
+                        [Newtonsoft.Json.JsonProperty("app_name")]
+                        [System.Text.Json.Serialization.JsonPropertyName("app_name")]
+                        public string? AppName { get; set; }
+
+                        /// <summary>
+                        /// IOS移动应用bundle_id。
+                        /// </summary>
+                        [Newtonsoft.Json.JsonProperty("bundle_id")]
+                        [System.Text.Json.Serialization.JsonPropertyName("bundle_id")]
+                        public string? BundleId { get; set; }
+
+                        /// <summary>
+                        /// 安卓移动应用包名。
+                        /// </summary>
+                        [Newtonsoft.Json.JsonProperty("package_name")]
+                        [System.Text.Json.Serialization.JsonPropertyName("package_name")]
+                        public string? PackageName { get; set; }
+
+                        /// <summary>
+                        /// WAP网站应用-WAP网站URL地址。
+                        /// </summary>
+                        [Newtonsoft.Json.JsonProperty("wap_url")]
+                        [System.Text.Json.Serialization.JsonPropertyName("wap_url")]
+                        public string? WapUrl { get; set; }
+
+                        /// <summary>
+                        /// WAP网站应用-WAP 网站名。
+                        /// </summary>
+                        [Newtonsoft.Json.JsonProperty("wap_name")]
+                        [System.Text.Json.Serialization.JsonPropertyName("wap_name")]
+                        public string? WapName { get; set; }
+                    }
                 }
 
                 /// <summary>
@@ -131,6 +176,13 @@ namespace SKIT.FlurlHttpClient.Wechat.TenpayV2.Models
                 [Newtonsoft.Json.JsonProperty("store_info")]
                 [System.Text.Json.Serialization.JsonPropertyName("store_info")]
                 public Types.Store? Store { get; set; }
+
+                /// <summary>
+                /// 获取或设置IOS移动应用/安卓移动应用/WAP网站应用。
+                /// </summary>
+                [Newtonsoft.Json.JsonProperty("h5_info")]
+                [System.Text.Json.Serialization.JsonPropertyName("h5_info")]
+                public Types.H5Info? H5Info { get; set; }
             }
         }
 


### PR DESCRIPTION
当使用H5支付（https://pay.weixin.qq.com/doc/v2/merchant/4011937163）时，scene_info为必传变量，但缺少对应type

![image](https://github.com/user-attachments/assets/ff8d13c8-59fe-4c67-846d-bc0d92f42450)
